### PR TITLE
Renamed `mosaicNonce` to `nonce` as provided by core database

### DIFF
--- a/spec/openapi3.yaml
+++ b/spec/openapi3.yaml
@@ -2092,11 +2092,11 @@ components:
     MosaicDefinitionTransactionBodyDTO:
       type: object
       required:
-        - mosaicNonce
+        - nonce
         - mosaicId
         - properties
       properties:
-        mosaicNonce:
+        nonce:
           type: integer
           format: int64
           description: Random nonce used to generate the mosaic id.


### PR DESCRIPTION
Addresses https://github.com/nemtech/catapult-rest/issues/82 , I assume it should be `nonce` instead of `mosaicNonce` in accordance to:

- MongoDb schema
- Catbuffer (https://github.com/nemtech/catbuffer/blob/master/schemas/mosaic/mosaic_definition.cats#L7)
