### PR TITLE
Fix key transactions

### DIFF
--- a/spec/openapi3.yaml
+++ b/spec/openapi3.yaml
@@ -933,7 +933,7 @@ paths:
   "/metadata/account/{accountId}":
     get:
       tags:
-      - Metadata routes
+        - Metadata routes
       summary: Get account metadata
       description: Returns the account metadata given an account id.
       operationId: getAccountMetadata
@@ -948,7 +948,7 @@ paths:
           content:
             application/json:
               schema:
-                  $ref: "#/components/schemas/MetadataEntriesDTO"
+                $ref: "#/components/schemas/MetadataEntriesDTO"
         "404":
           description: resource not found
         "409":
@@ -956,7 +956,7 @@ paths:
   "/metadata/mosaic/{mosaicId}":
     get:
       tags:
-      - Metadata routes
+        - Metadata routes
       summary: Get mosaic metadata
       description: Returns the mosaic metadata given a mosaic id.
       operationId: getMosaicMetadata
@@ -971,7 +971,7 @@ paths:
           content:
             application/json:
               schema:
-                  $ref: "#/components/schemas/MetadataEntriesDTO"
+                $ref: "#/components/schemas/MetadataEntriesDTO"
         "404":
           description: resource not found
         "409":
@@ -979,7 +979,7 @@ paths:
   "/metadata/namespace/{namespaceId}":
     get:
       tags:
-      - Metadata routes
+        - Metadata routes
       summary: Get namespace metadata
       description: Returns the namespace metadata given a namespace id.
       operationId: getNamespaceMetadata
@@ -994,7 +994,7 @@ paths:
           content:
             application/json:
               schema:
-                  $ref: "#/components/schemas/MetadataEntriesDTO"
+                $ref: "#/components/schemas/MetadataEntriesDTO"
         "404":
           description: resource not found
         "409":
@@ -1002,7 +1002,7 @@ paths:
   "/metadata/account/{accountId}/key/{key}":
     get:
       tags:
-      - Metadata routes
+        - Metadata routes
       summary: Get account metadata
       description: Returns the account metadata given an account id and a key
       operationId: getAccountMetadataByKey
@@ -1015,7 +1015,7 @@ paths:
           content:
             application/json:
               schema:
-                  $ref: "#/components/schemas/MetadataEntriesDTO"
+                $ref: "#/components/schemas/MetadataEntriesDTO"
         "404":
           description: resource not found
         "409":
@@ -1023,7 +1023,7 @@ paths:
   "/metadata/mosaic/{mosaicId}/key/{key}":
     get:
       tags:
-      - Metadata routes
+        - Metadata routes
       summary: Get mosaic metadata
       description: Returns the mosaic metadata given a mosaic id and a key
       operationId: getMosaicMetadataByKey
@@ -1036,7 +1036,7 @@ paths:
           content:
             application/json:
               schema:
-                  $ref: "#/components/schemas/MetadataEntriesDTO"
+                $ref: "#/components/schemas/MetadataEntriesDTO"
         "404":
           description: resource not found
         "409":
@@ -1044,7 +1044,7 @@ paths:
   "/metadata/namespace/{namespaceId}/key/{key}":
     get:
       tags:
-      - Metadata routes
+        - Metadata routes
       summary: Get namespace metadata
       description: Returns the namespace metadata given a namespace id and a key
       operationId: getNamespaceMetadataByKey
@@ -1057,7 +1057,7 @@ paths:
           content:
             application/json:
               schema:
-                  $ref: "#/components/schemas/MetadataEntriesDTO"
+                $ref: "#/components/schemas/MetadataEntriesDTO"
         "404":
           description: resource not found
         "409":
@@ -1065,7 +1065,7 @@ paths:
   "/metadata/account/{accountId}/key/{key}/sender/{publicKey}":
     get:
       tags:
-      - Metadata routes
+        - Metadata routes
       summary: Get account metadata
       description: Returns the account metadata given an account id, a key, and a sender
       operationId: getAccountMetadataByKeyAndSender
@@ -1079,7 +1079,7 @@ paths:
           content:
             application/json:
               schema:
-                  $ref: "#/components/schemas/MetadataDTO"
+                $ref: "#/components/schemas/MetadataDTO"
         "404":
           description: resource not found
         "409":
@@ -1087,7 +1087,7 @@ paths:
   "/metadata/mosaic/{mosaicId}/key/{key}/sender/{publicKey}":
     get:
       tags:
-      - Metadata routes
+        - Metadata routes
       summary: Get mosaic metadata
       description: Returns the mosaic metadata given a mosaic id, a key, and a sender
       operationId: getMosaicMetadataByKeyAndSender
@@ -1101,7 +1101,7 @@ paths:
           content:
             application/json:
               schema:
-                  $ref: "#/components/schemas/MetadataDTO"
+                $ref: "#/components/schemas/MetadataDTO"
         "404":
           description: resource not found
         "409":
@@ -1109,7 +1109,7 @@ paths:
   "/metadata/namespace/{namespaceId}/key/{key}/sender/{publicKey}":
     get:
       tags:
-      - Metadata routes
+        - Metadata routes
       summary: Get namespace metadata
       description: Returns the namespace metadata given a namespace id, a key, and a sender
       operationId: getNamespaceMetadataByKeyAndSender
@@ -1123,7 +1123,7 @@ paths:
           content:
             application/json:
               schema:
-                  $ref: "#/components/schemas/MetadataDTO"
+                $ref: "#/components/schemas/MetadataDTO"
         "404":
           description: resource not found
         "409":
@@ -2159,6 +2159,9 @@ components:
             - $ref: "#/components/schemas/NamespaceRegistrationTransactionDTO"
             - $ref: "#/components/schemas/AddressAliasTransactionDTO"
             - $ref: "#/components/schemas/MosaicAliasTransactionDTO"
+            - $ref: "#/components/schemas/AccountMetadataTransactionDTO"
+            - $ref: "#/components/schemas/MosaicMetadataTransactionDTO"
+            - $ref: "#/components/schemas/NamespaceMetadataTransactionDTO"
             - $ref: "#/components/schemas/HashLockTransactionDTO"
             - $ref: "#/components/schemas/SecretLockTransactionDTO"
             - $ref: "#/components/schemas/SecretProofTransactionDTO"
@@ -2205,6 +2208,9 @@ components:
             - $ref: "#/components/schemas/EmbeddedNamespaceRegistrationTransactionDTO"
             - $ref: "#/components/schemas/EmbeddedAddressAliasTransactionDTO"
             - $ref: "#/components/schemas/EmbeddedMosaicAliasTransactionDTO"
+            - $ref: "#/components/schemas/EmbeddedAccountMetadataTransactionDTO"
+            - $ref: "#/components/schemas/EmbeddedMosaicMetadataTransactionDTO"
+            - $ref: "#/components/schemas/EmbeddedNamespaceMetadataTransactionDTO"
             - $ref: "#/components/schemas/EmbeddedHashLockTransactionDTO"
             - $ref: "#/components/schemas/EmbeddedSecretLockTransactionDTO"
             - $ref: "#/components/schemas/EmbeddedSecretProofTransactionDTO"
@@ -2636,7 +2642,7 @@ components:
       allOf:
         - $ref: "#/components/schemas/TransactionDTO"
         - $ref: "#/components/schemas/AccountMetadataTransactionBodyDTO"
-    EmbeddedAccountMetadataTransactionTransactionDTO:
+    EmbeddedAccountMetadataTransactionDTO:
       allOf:
         - $ref: "#/components/schemas/EmbeddedTransactionDTO"
         - $ref: "#/components/schemas/AccountMetadataTransactionBodyDTO"
@@ -2652,7 +2658,6 @@ components:
       properties:
         targetPublicKey:
           $ref: "#/components/schemas/PublicKey"
-          description: Metadata target public key.
         scopedMetadataKey:
           $ref: "#/components/schemas/MetadataKey"
         targetMosaicId:
@@ -2675,7 +2680,7 @@ components:
       allOf:
         - $ref: "#/components/schemas/TransactionDTO"
         - $ref: "#/components/schemas/MosaicMetadataTransactionBodyDTO"
-    EmbeddedMosaicMetadataTransactionTransactionDTO:
+    EmbeddedMosaicMetadataTransactionDTO:
       allOf:
         - $ref: "#/components/schemas/EmbeddedTransactionDTO"
         - $ref: "#/components/schemas/MosaicMetadataTransactionBodyDTO"
@@ -2691,7 +2696,6 @@ components:
       properties:
         targetPublicKey:
           $ref: "#/components/schemas/PublicKey"
-          description: Metadata target public key.
         scopedMetadataKey:
           $ref: "#/components/schemas/MetadataKey"
         targetNamespaceId:
@@ -2714,7 +2718,7 @@ components:
       allOf:
         - $ref: "#/components/schemas/TransactionDTO"
         - $ref: "#/components/schemas/NamespaceMetadataTransactionBodyDTO"
-    EmbeddedNamespaceMetadataTransactionTransactionDTO:
+    EmbeddedNamespaceMetadataTransactionDTO:
       allOf:
         - $ref: "#/components/schemas/EmbeddedTransactionDTO"
         - $ref: "#/components/schemas/NamespaceMetadataTransactionBodyDTO"

--- a/spec/openapi3.yaml
+++ b/spec/openapi3.yaml
@@ -234,6 +234,94 @@ paths:
           $ref : "#/components/responses/InvalidContent"
         "409":
           $ref : "#/components/responses/InvalidArgument"
+  "/restrictions/mosaic/{mosaicId}":
+    get:
+      tags:
+        - Restriction routes
+      summary: Get mosaic global restriction for a given mosaic identifier.
+      description: Get mosaic global restriction.
+      operationId: getMosaicGlobalRestriction
+      parameters:
+        - $ref: "#/components/parameters/mosaicId"
+      responses:
+        "200":
+          description: success
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MosaicGlobalRestrictionDTO"
+        "404":
+          $ref: "#/components/responses/ResourceNotFound"
+        "409":
+          $ref: "#/components/responses/InvalidArgument"
+    post:
+      tags:
+        - Restriction routes
+      summary: Get mosaic address restrictions for a given mosaic and account identifiers array.
+      description: Get mosaic address restrictions.
+      operationId: getMosaicAddressRestrictions
+      parameters:
+        - $ref: "#/components/parameters/mosaicId"
+      requestBody:
+        $ref: "#/components/requestBodies/accountIds"
+      responses:
+        "200":
+          description: success
+          content:
+            application/json:
+              schema:
+                type: array
+                description: Array of mosaics address restrictions.
+                items:
+                  $ref: "#/components/schemas/MosaicAddressRestrictionDTO"
+        "400":
+          $ref : "#/components/responses/InvalidContent"
+        "409":
+          $ref : "#/components/responses/InvalidArgument"
+  "/restrictions/mosaic/{mosaicId}/address/{accountId}":
+    get:
+      tags:
+        - Restriction routes
+      summary: Get mosaic address restrictions for a given mosaic and account identifier.
+      description: Get mosaic address restriction.
+      operationId: getMosaicAddressRestriction
+      parameters:
+        - $ref: "#/components/parameters/mosaicId"
+        - $ref: "#/components/parameters/accountId"
+      responses:
+        "200":
+          description: success
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MosaicAddressRestrictionDTO"
+        "404":
+          $ref: "#/components/responses/ResourceNotFound"
+        "409":
+          $ref: "#/components/responses/InvalidArgument"
+  /restrictions/mosaic:
+    post:
+      tags:
+        - Restriction routes
+      summary: Get mosaic global restrictions for an array of mosaics.
+      description: Get mosaic global restrictions.
+      operationId: getMosaicGlobalRestrictions
+      requestBody:
+        $ref: "#/components/requestBodies/mosaicIds"
+      responses:
+        "200":
+          description: success
+          content:
+            application/json:
+              schema:
+                type: array
+                description: Array of mosaics global restrictions.
+                items:
+                  $ref: "#/components/schemas/MosaicGlobalRestrictionDTO"
+        "400":
+          $ref : "#/components/responses/InvalidContent"
+        "409":
+          $ref : "#/components/responses/InvalidArgument"
   "/account/{accountId}/multisig":
     get:
       tags:
@@ -1443,6 +1531,16 @@ components:
         * 0  - Decrease.
         * 1  - Increase.
       example: 0
+    # Enumerations - Mosaic restriction entry type
+    MosaicRestrictionEntryTypeEnum:
+      type: integer
+      format: int32
+      enum:
+        - 0
+        - 1
+      description: |
+        - 0 - Mosaic address restriction.
+        - 1 - Mosaic global restriction.
     # Enumerations - Multisig
     CosignatoryModificationActionEnum:
       type: integer
@@ -3165,6 +3263,100 @@ components:
       allOf:
         - $ref: "#/components/schemas/EmbeddedTransactionDTO"
         - $ref: "#/components/schemas/MosaicGlobalRestrictionTransactionBodyDTO"
+    MosaicRestrictionKey:
+      type: string
+      format: hex
+      description: Restriction key.
+      example: 0DC67FBE1CAD29E3
+    MosaicGlobalRestrictionEntryRestrictionDTO:
+      type: object
+      required:
+        - referenceMosaicId
+        - restrictionValue
+        - restrictionType
+      properties:
+        referenceMosaicId:
+          $ref: "#/components/schemas/MosaicId"
+        restrictionValue:
+          type: string
+          description: Restriction value.
+        restrictionType:
+          $ref: "#/components/schemas/MosaicRestrictionTypeEnum"
+    MosaicGlobalRestrictionEntryDTO:
+      type: object
+      required:
+        - key
+        - restriction
+      properties:
+        key:
+          $ref: "#/components/schemas/MosaicRestrictionKey"
+        restriction:
+          $ref: "#/components/schemas/MosaicGlobalRestrictionEntryRestrictionDTO"
+    MosaicGlobalRestrictionEntryWrapperDTO:
+      type: object
+      required:
+        - compositeHash
+        - entryType
+        - mosaicId
+        - restrictions
+      properties:
+        compositeHash:
+          $ref: "#/components/schemas/Hash256"
+        entryType:
+          $ref: "#/components/schemas/MosaicRestrictionEntryTypeEnum"
+        mosaicId:
+          $ref: "#/components/schemas/MosaicId"
+        restrictions:
+          type: array
+          items:
+            $ref: "#/components/schemas/MosaicGlobalRestrictionEntryDTO"
+    MosaicGlobalRestrictionDTO:
+      type: object
+      required:
+        - mosaicRestrictionEntry
+      properties:
+        mosaicRestrictionEntry:
+          $ref: "#/components/schemas/MosaicGlobalRestrictionEntryWrapperDTO"
+    MosaicAddressRestrictionEntryDTO:
+      type: object
+      required:
+        - key
+        - value
+      properties:
+        key:
+          $ref: "#/components/schemas/MosaicRestrictionKey"
+        value:
+          type: string
+          description: Restriction value.
+    MosaicAddressRestrictionEntryWrapperDTO:
+      type: object
+      required:
+        - compositeHash
+        - entryType
+        - mosaicId
+        - targetAddress
+        - restrictions
+      properties:
+        compositeHash:
+          $ref: "#/components/schemas/Hash256"
+        entryType:
+          $ref: "#/components/schemas/MosaicRestrictionEntryTypeEnum"
+        mosaicId:
+          $ref: "#/components/schemas/MosaicId"
+        targetAddress:
+          $ref: "#/components/schemas/Address"
+        restrictions:
+          type: array
+          items:
+            $ref: "#/components/schemas/MosaicAddressRestrictionEntryDTO"
+    MosaicAddressRestrictionDTO:
+      type: object
+      required:
+        - mosaicRestrictionEntry
+      properties:
+        mosaicRestrictionEntry:
+          $ref: "#/components/schemas/MosaicAddressRestrictionEntryWrapperDTO"
+
     # Schemas - Transfer
     MessageDTO:
       type: object

--- a/spec/openapi3.yaml
+++ b/spec/openapi3.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  version: 0.7.18
+  version: 0.7.19
   title: Catapult REST Endpoints
   license:
     name: Apache 2.0
@@ -3449,8 +3449,11 @@ components:
         valueSize:
           type: integer
           format: int32
+          description: Size of value property.
         value:
           type: string
+          format: hex
+          description: Metadata value.
 
     # Request bodies
     accountIds:

--- a/spec/openapi3.yaml
+++ b/spec/openapi3.yaml
@@ -3210,7 +3210,7 @@ components:
         mosaicId:
           $ref: "#/components/schemas/UnresolvedMosaicId"
         restrictionKey:
-          - $ref: "#/components/schemas/MosaicRestrictionKey"
+          $ref: "#/components/schemas/MosaicRestrictionKey"
         targetAddress:
           $ref: "#/components/schemas/UnresolvedAddress"
         previousRestrictionValue:
@@ -3246,7 +3246,7 @@ components:
         referenceMosaicId:
           $ref: "#/components/schemas/UnresolvedMosaicId"
         restrictionKey:
-          - $ref: "#/components/schemas/MosaicRestrictionKey"
+          $ref: "#/components/schemas/MosaicRestrictionKey"
         previousRestrictionValue:
           type: string
           description: Previous restriction value.

--- a/spec/openapi3.yaml
+++ b/spec/openapi3.yaml
@@ -1329,14 +1329,6 @@ components:
       type: string
       description: Probability of an account to harvest the next block.
       example: 0
-    PublicKey:
-      type: string
-      example: AC1A6E1D8DE5B17D2C6B1293F1CAD3829EEACF38D09311BB3C8E5A880092DE26
-    MosaicId:
-      type: string
-      format: hex
-      description: Mosaic identifier.
-      example: 0DC67FBE1CAD29E3
     ModelError:
       type: object
       required:
@@ -1347,11 +1339,29 @@ components:
           type: string
         message:
           type: string
+    MetadataKey:
+      type: string
+      format: hex
+      description: Metadata key scoped to source, target and type.
+      example: 0DC67FBE1CAD29E3
+    MosaicId:
+      type: string
+      format: hex
+      description: Mosaic identifier.
+      example: 0DC67FBE1CAD29E3
+    MosaicRestrictionKey:
+      type: string
+      format: hex
+      description: Restriction key.
+      example: 0DC67FBE1CAD29E3
     NamespaceId:
       type: string
       format: hex
       description: Namespace identifier.
       example: 85BBEA6CC462B244
+    PublicKey:
+      type: string
+      example: AC1A6E1D8DE5B17D2C6B1293F1CAD3829EEACF38D09311BB3C8E5A880092DE26
     Score:
       type: string
       description: |
@@ -2607,8 +2617,7 @@ components:
           $ref: "#/components/schemas/PublicKey"
           description: Metadata target public key.
         scopedMetadataKey:
-          type: string
-          description: Metadata key scoped to source, target and type.
+          $ref: "#/components/schemas/MetadataKey"
         valueSizeDelta:
           type: integer
           format: int32
@@ -2645,8 +2654,7 @@ components:
           $ref: "#/components/schemas/PublicKey"
           description: Metadata target public key.
         scopedMetadataKey:
-          type: string
-          description: Metadata key scoped to source, target and type.
+          $ref: "#/components/schemas/MetadataKey"
         targetMosaicId:
           $ref: "#/components/schemas/UnresolvedMosaicId"
         valueSizeDelta:
@@ -2685,8 +2693,7 @@ components:
           $ref: "#/components/schemas/PublicKey"
           description: Metadata target public key.
         scopedMetadataKey:
-          type: string
-          description: Metadata key scoped to source, target and type.
+          $ref: "#/components/schemas/MetadataKey"
         targetNamespaceId:
           $ref: "#/components/schemas/NamespaceId"
         valueSizeDelta:
@@ -3203,8 +3210,7 @@ components:
         mosaicId:
           $ref: "#/components/schemas/UnresolvedMosaicId"
         restrictionKey:
-          type: string
-          description: Restriction key relative to the reference mosaic identifier.
+          - $ref: "#/components/schemas/MosaicRestrictionKey"
         targetAddress:
           $ref: "#/components/schemas/UnresolvedAddress"
         previousRestrictionValue:
@@ -3240,8 +3246,7 @@ components:
         referenceMosaicId:
           $ref: "#/components/schemas/UnresolvedMosaicId"
         restrictionKey:
-          type: string
-          description: Restriction key relative to the reference mosaic identifier.
+          - $ref: "#/components/schemas/MosaicRestrictionKey"
         previousRestrictionValue:
           type: string
           description: Previous restriction value.
@@ -3263,11 +3268,6 @@ components:
       allOf:
         - $ref: "#/components/schemas/EmbeddedTransactionDTO"
         - $ref: "#/components/schemas/MosaicGlobalRestrictionTransactionBodyDTO"
-    MosaicRestrictionKey:
-      type: string
-      format: hex
-      description: Restriction key.
-      example: 0DC67FBE1CAD29E3
     MosaicGlobalRestrictionEntryRestrictionDTO:
       type: object
       required:
@@ -3438,8 +3438,7 @@ components:
         targetPublicKey:
           $ref: "#/components/schemas/PublicKey"
         scopedMetadataKey:
-          type: string
-          format: hex
+          $ref: "#/components/schemas/MetadataKey"
         targetId:
           anyOf:
             - $ref: "#/components/schemas/MosaicId"


### PR DESCRIPTION
* Minor linter warning changes
* Metadata and restriction keys moved to a separate model.

How this change affects REST:

Noticed that the ``restrictionKey`` used in the [mosaic restriction transactions](https://github.com/nemtech/nem2-openapi/pull/35/files#diff-10617bf1c6f83b43249cd01afc90ac56R3217) was not defined with ``format:hex``, whereas the state one it was. Please, consider formatting the transaction restriction key as hexadecimal on the REST side.